### PR TITLE
Refactored testing helper function into generateTeamData function;

### DIFF
--- a/database/utils/generateData.js
+++ b/database/utils/generateData.js
@@ -242,6 +242,29 @@ const insertOrg = (
   })
 }
 
+// This is a test utility that populates a database with test data
+// for a single team, and returns the team as an object, along with a
+// cleanup function that can be called to cleanup the data aftewards.
+
+// It takes a knex instance, it then inserts a randomly generated
+// team into knex. It returns an object with two properties:
+
+// First: a team object with the following shape:
+// { organization, users, availabilities, events, timeOffRequests }
+
+// Second: a cleanup function, which is an async function that should be
+// called to clean up the database afterwards
+const generateTeamData = async knex => {
+  const team = populateOrg()
+  await insertOrg(team, knex)
+
+  const cleanup = async () => {
+    await knex('organizations').delete({ id: team.organization.id })
+  }
+
+  return { team, cleanup }
+}
+
 module.exports = {
   generateOrg,
   generateOrgs,
@@ -252,5 +275,5 @@ module.exports = {
   generateDayOffRequests,
   generateEvents,
   populateOrg,
-  insertOrg
+  generateTeamData
 }


### PR DESCRIPTION
# Description

Lowered the surface area of prior generateOrg and deleteOrg into a single generateTeamData function. 

This is a test utility that populates a database with test data
for a single team, and returns the team as an object, along with a
cleanup function that can be called to cleanup the data aftewards.

It takes a knex instance, it then inserts a randomly generated
team into knex. It returns an object with two properties:

First: a team object with the following shape:
{ organization, users, availabilities, events, timeOffRequests }

Second: a cleanup function, which is an async function that should be
called to clean up the database afterwards


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Change status
- [X] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My code has been reviewed by at least one peer
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] There are no merge conflicts