### PR TITLE
Fix generateTeam cleanup function and build out organizationsRouter t…

### DIFF
--- a/__tests__/organizationsRouter.js
+++ b/__tests__/organizationsRouter.js
@@ -61,8 +61,15 @@ describe('testing the organizations router', () => {
         .post('/organizations')
         .send(org)
         .set('authorization', 'testing')
-      expect(response.body).toEqual([1])
+      expect(response.body.length).toEqual(1)
       expect(response.status).toBe(201)
+
+      const target = await knex('organizations').where(org)
+      expect(target.length).toEqual(1)
+
+      await knex('organizations')
+        .delete()
+        .where(org)
     })
 
     it('can reject an empty organization', async () => {
@@ -93,7 +100,13 @@ describe('testing the organizations router', () => {
       expect(edit.status).toBe(200)
       expect(response.body.name).toBe('Edited Org')
 
-      await cleanup
+      const target = await knex('organizations')
+        .where('id', id)
+        .select('name')
+        .first()
+      expect(target.name).toBe('Edited Org')
+
+      await cleanup()
     })
 
     it('can reject an empty organization', async () => {

--- a/database/helpers/organizationsModel.js
+++ b/database/helpers/organizationsModel.js
@@ -23,6 +23,9 @@ const updateOrg = (orgId, updates) => {
 }
 
 const deleteOrg = orgId => {
+  if (orgId === undefined) {
+    return Promise.reject('deleteOrg requires an argument')
+  }
   return db('organizations as o')
     .where({ 'o.id': orgId })
     .del()

--- a/database/utils/generateData.js
+++ b/database/utils/generateData.js
@@ -258,8 +258,10 @@ const generateTeamData = async knex => {
   const team = populateOrg()
   await insertOrg(team, knex)
 
-  const cleanup = async () => {
-    await knex('organizations').delete({ id: team.organization.id })
+  const cleanup = () => {
+    return knex('organizations')
+      .where('id', team.organization.id)
+      .del()
   }
 
   return { team, cleanup }


### PR DESCRIPTION
Description
cleanup function from generateTeamData was clearing full database due to a syntax error. Fixed.
The fix revealed a expectation in orgRouter tests that was incorrect, which was updated. Some custom cleanup added to orgRouter tests too.

Fixes # (issue)

Type of change
Please delete options that are not relevant.

[x ] Bug fix (non-breaking change which fixes an issue)
  New feature (non-breaking change which adds functionality)
  Breaking change (fix or feature that would cause existing functionality to not work as expected)
  This change requires a documentation update
Change status
[x ] Complete, tested, ready to review and merge
  Complete, but not tested (may need new tests)
  Incomplete/work-in-progress, PR is for discussion/feedback
How Has This Been Tested?
All tests are passing and database is no longer empty after testing.

Checklist:
[ x] My code follows the style guidelines of this project
[ x] I have performed a self-review of my own code
[ x] My code has been reviewed by at least one peer
[ x] I have commented my code, particularly in hard-to-understand areas
[ x] I have made corresponding changes to the documentation
[ x] My changes generate no new warnings
[ x] I have added tests that prove my fix is effective or that my feature works
[ x] New and existing unit tests pass locally with my changes
[ x] There are no merge conflicts