### PR TITLE
bug fix for resizing shift

### DIFF
--- a/client/src/components/Scheduler/index.js
+++ b/client/src/components/Scheduler/index.js
@@ -188,7 +188,8 @@ class Scheduler extends React.Component {
   resizeEvent = ({ end, start, event }) => {
     const { verdict, message } = this.validateEvent({
       userId: event.user_id,
-      eventTimes: { start, end }
+      eventTimes: { start, end },
+      eventId: event.id
     })
     if (verdict) {
       this.props.changeEvent(


### PR DESCRIPTION
# Description
Resizing shift was causing the validation to find a shift collision. I extended the ignore collisions for id equivalent shifts exception to resizing. 