### PR TITLE
makes /shift-calendar take up 100vh

### DIFF
--- a/client/src/components/Scheduler/index.js
+++ b/client/src/components/Scheduler/index.js
@@ -437,6 +437,7 @@ export default connect(
 
 const Container = styled.div`
   display: flex;
+  min-height: 100vh;
 
   @media ${system.breakpoints[0]} {
     flex-direction: column;


### PR DESCRIPTION
# Description

fixes bug on /shift-calendar where the calendar would appear to be cutoff before the bottom of the screen.



- [X] Bug fix (non-breaking change which fixes an issue)


## Change status
- [X] Complete, tested, ready to review and merge


# How Has This Been Tested?

just CSS no tests needed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts