### PR TITLE
Add tablet responsiveness to dashcal toggles

### DIFF
--- a/client/src/components/EmployeeDashboard.js
+++ b/client/src/components/EmployeeDashboard.js
@@ -191,9 +191,9 @@ class EmployeeDashboard extends Component {
           <CalendarButtons>
             <NavButtons>
               <Button onClick={() => this.changeDate('left')}>&#8592;</Button>
-              <MiddleButton onClick={() => this.changeDate('today')}>
+              <ToggleButton onClick={() => this.changeDate('today')}>
                 Today
-              </MiddleButton>
+              </ToggleButton>
               <Button onClick={() => this.changeDate('right')}>&#8594;</Button>
               {width === 'mobile' || width === 'tablet' ? (
                 <ToggleButton onClick={this.toggleEmployeeView}>
@@ -362,19 +362,10 @@ const NavButtons = styled.div`
     justify-content: space-around;
   }
 `
-
-const MiddleButton = styled(Button)`
-  @media ${system.breakpoints[0]} {
+const ToggleButton = styled(Button)`
+  @media ${system.breakpoints[1]} {
     margin-bottom: ${system.spacing.bigPadding};
     order: -1;
     width: 100%;
-  }
-`
-
-const ToggleButton = styled(Button)`
-  @media ${system.breakpoints[0]} {
-    margin-top: ${system.spacing.bigPadding};
-    /* order: -1; */
-    /* width: 100%; */
   }
 `


### PR DESCRIPTION
# Description

Makes both dashboard calendar toggle buttons go full screen stretch at tablet breakpoints 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Change status
- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

tested in browser

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts