### PR TITLE
fix scrunching of firebase modal on small screens

### DIFF
--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -89,10 +89,6 @@ const Container = styled('div')`
     width: 100%;
     margin: 20px 0;
 
-    @media ${system.breakpoints[1]} {
-      width: ${props => (props.settings ? '100%' : '80%')};
-    }
-
     label {
       font-size: ${system.fontSizing.s};
       padding: 0 5px;


### PR DESCRIPTION
# Description
The container for the modal was reducing the width to 80% at a specific media break point. I removed that and it doesn't scrunch any more. 