### PR TITLE
Demos for owners only, and move Stripe plan id onto process.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ REACT_APP_STRIPE_PKEY={insert Stripe publishable key here}
 ```
 
 ##### Server:
-The server will need 6 environment variables. You can copy-paste the first. You will need to create your own for the rest. <br/><br/>
+The server will need 7 environment variables. You can copy-paste the first. You will need to create your own for the rest. <br/><br/>
 `GMAIL_USERNAME` and `GMAIL_PASSWORD` refer to the literal username and password for a Gmail account. You need a Gmail account wired up to our app in order to send invites to new users. Said Gmail account must have access for "less secure apps" enabled, which you can learn how to do [here](https://support.google.com/accounts/answer/6010255?hl=en). It is inadvisable to use your personal Gmail for this.
 <br/><br/>
 For your `FIREBASE_SECRET`, go to your Firebase project settings. Go to the tab for "Service Accounts" and click the "Generate new private key" button. This will auto-download a JSON object. Open it up in your text editor; copy the value for the key "private_key"; it (as a string) is your `FIREBASE_SECRET`. 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ REACT_APP_STRIPE_PKEY={insert Stripe publishable key here}
 ```
 
 ##### Server:
-The server will need 5 environment variables. You can copy-paste the first. You will need to create your own for the rest. <br/><br/>
+The server will need 6 environment variables. You can copy-paste the first. You will need to create your own for the rest. <br/><br/>
 `GMAIL_USERNAME` and `GMAIL_PASSWORD` refer to the literal username and password for a Gmail account. You need a Gmail account wired up to our app in order to send invites to new users. Said Gmail account must have access for "less secure apps" enabled, which you can learn how to do [here](https://support.google.com/accounts/answer/6010255?hl=en). It is inadvisable to use your personal Gmail for this.
 <br/><br/>
 For your `FIREBASE_SECRET`, go to your Firebase project settings. Go to the tab for "Service Accounts" and click the "Generate new private key" button. This will auto-download a JSON object. Open it up in your text editor; copy the value for the key "private_key"; it (as a string) is your `FIREBASE_SECRET`. 
@@ -73,6 +73,8 @@ For your `FIREBASE_SECRET`, go to your Firebase project settings. Go to the tab 
 For your `FIREBASE_EMAIL`, open the JSON object mentioned in the previous step in your text editor. Copy the value for the key "client_email". It will be a url ending in "gserviceaccount.com"; this is your `FIREBASE_EMAIL`.
 <br/><br/>
 Go to your Stripe [dashboard](https://dashboard.stripe.com/account/apikeys) and copy-paste your "Secret key" as your `STRIPE_SKEY`. It is best to use your test keys so as not to run up a bill.
+<br/><br/>
+Go to your Stripe dashboard [products page](https://dashboard.stripe.com/account/apikeys) and make a Product plan. Then take the product ID, and swap `plan_` for `prod_`. So `prod_XXXXXXXX becomes `plan_XXXXXXXX`. Save this as your `STRIPE_PLAN_ID`.
 ```
 CLIENT_URL=http://localhost:3000
 GMAIL_USERNAME={insert your Gmail address here}
@@ -80,6 +82,7 @@ GMAIL_PASSWORD={insert your Gmail password here}
 FIREBASE_SECRET={copy paste your "private_key" here}
 FIREBASE_EMAIL={copy paste your "client_email" here}
 STRIPE_SKEY={insert Stripe secret key here}
+STRIPE_PLAN_ID={insert your plan_id here}
 ```
 
 ### Using the App

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -78,6 +78,7 @@ class App extends Component {
 
   establishStripe = () => {
     const stripePKey = process.env.REACT_APP_STRIPE_PKEY
+    console.log(stripePKey)
     this.setState({
       stripe: window.Stripe(stripePKey)
     })

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -78,7 +78,6 @@ class App extends Component {
 
   establishStripe = () => {
     const stripePKey = process.env.REACT_APP_STRIPE_PKEY
-    console.log(stripePKey)
     this.setState({
       stripe: window.Stripe(stripePKey)
     })

--- a/client/src/__tests__/EmployeeDashboards.js
+++ b/client/src/__tests__/EmployeeDashboards.js
@@ -33,7 +33,7 @@ const employee = employees.find(
 const user = employeeCandidates.find(nonOwner => nonOwner.id === employee.id)
 user.cal_visit = false
 user.emp_visit = false
-console.log(employee.events[0].start)
+
 describe('employee dashboard with redux', () => {
   afterEach(cleanup)
   it('can render with initial state', async () => {

--- a/client/src/components/HoursOfOperationForm.js
+++ b/client/src/components/HoursOfOperationForm.js
@@ -52,7 +52,6 @@ const HoursOfOperation = props => {
 
   // for submitting all of the hours
   const submitHandler = () => {
-    console.log(days)
     days.forEach(day => {
       if (day.updated) {
         const start = moment(day.start, 'h:mm a')

--- a/client/src/components/Scheduler/index.js
+++ b/client/src/components/Scheduler/index.js
@@ -53,7 +53,7 @@ class Scheduler extends React.Component {
   componentDidMount() {
     // if redux shows that this state is true, create dummy employees
     const { user } = this.props
-    if (user && user.cal_visit === true) {
+    if (user && user.role === 'owner' && user.cal_visit === true) {
       const baseURL = process.env.REACT_APP_SERVER_URL
       const offset = moment().utcOffset()
       // load the demo steps

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,5 +9,5 @@ to = "/index.html"
 status = 200
 
 [context.pts.environment]
-  REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com
+  REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com"
   REACT_APP_STRIPE_PKEY="'pk_test_HKBgYIhIo21X8kQikefX3Ei1'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -9,4 +9,5 @@ to = "/index.html"
 status = 200
 
 [context.pts.environment]
-  REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com"
+  REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com
+  REACT_APP_STRIPE_PKEY="'pk_test_HKBgYIhIo21X8kQikefX3Ei1'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,6 @@ command = "yarn build"
 from = "/*"
 to = "/index.html"
 status = 200
+
+[context.pts.environment]
+  REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@ status = 200
 
 [context.pts.environment]
   REACT_APP_SERVER_URL = "https://cadence-pts.herokuapp.com"
-  REACT_APP_STRIPE_PKEY="'pk_test_HKBgYIhIo21X8kQikefX3Ei1'"
+  REACT_APP_STRIPE_PKEY="pk_test_HKBgYIhIo21X8kQikefX3Ei1"

--- a/server/routers/paymentRouter.js
+++ b/server/routers/paymentRouter.js
@@ -10,9 +10,6 @@ const { updateOrg } = require('../../database/helpers')
 
 router.post('/', authorize(['owner']), (req, res) => {
   const { token, email, org_id } = req.body
-  console.log(stripeSKey)
-  console.log(plan)
-  console.log(req.body)
 
   stripe.customers.create(
     {

--- a/server/routers/paymentRouter.js
+++ b/server/routers/paymentRouter.js
@@ -1,6 +1,7 @@
 const express = require('express')
 const router = express.Router()
 const stripeSKey = process.env.STRIPE_SKEY
+const plan = process.env.STRIPE_PLAN_ID
 const stripe = require('stripe')(stripeSKey)
 const authorize = require('../config/customMiddleware/authorize')
 const { updateOrg } = require('../../database/helpers')
@@ -24,7 +25,7 @@ router.post('/', authorize(['owner']), (req, res) => {
             customer: customer.id,
             items: [
               {
-                plan: 'plan_EXHDMMgXpXCajr'
+                plan
               }
             ]
           },

--- a/server/routers/paymentRouter.js
+++ b/server/routers/paymentRouter.js
@@ -6,8 +6,12 @@ const stripe = require('stripe')(stripeSKey)
 const authorize = require('../config/customMiddleware/authorize')
 const { updateOrg } = require('../../database/helpers')
 
+
+
 router.post('/', authorize(['owner']), (req, res) => {
   const { token, email, org_id } = req.body
+  console.log(stripeSKey)
+  console.log(plan)
   console.log(req.body)
 
   stripe.customers.create(

--- a/server/routers/paymentRouter.js
+++ b/server/routers/paymentRouter.js
@@ -8,6 +8,7 @@ const { updateOrg } = require('../../database/helpers')
 
 router.post('/', authorize(['owner']), (req, res) => {
   const { token, email, org_id } = req.body
+  console.log(req.body)
 
   stripe.customers.create(
     {


### PR DESCRIPTION
# Description
Made demos for owners only to avoid creating multiple demo accounts when supervisors get invited., Moved Stripe plan id onto .env to have more flexibility with testing it.

Deploy preview here: https://pts--cadence.netlify.com

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

All tests passed, and went through firebase and Stripe flows in pts deploy:
https://pts--cadence.netlify.com

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts